### PR TITLE
Fix for Dynamic Extensions

### DIFF
--- a/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/admin/RecordsManagementAdminServiceImpl.java
+++ b/rm-community/rm-community-repo/source/java/org/alfresco/module/org_alfresco_module_rm/admin/RecordsManagementAdminServiceImpl.java
@@ -172,16 +172,18 @@ public class RecordsManagementAdminServiceImpl extends RecordsManagementAdminBas
     @Override
     public void onApplicationEvent(ContextRefreshedEvent event)
     {
-        transactionService.getRetryingTransactionHelper().doInTransaction(new RetryingTransactionCallback<Void>()
-        {
-            public Void execute() throws Throwable
-            {
-                // initialise custom properties
-                initCustomMap();
-                
-                return null;
-            }
-         });                 
+
+        if(!isCustomMapInit && getDictionaryService().getAllModels().contains(RM_CUSTOM_MODEL)) {
+            transactionService.getRetryingTransactionHelper().doInTransaction(new RetryingTransactionCallback<Void>() {
+                public Void execute() throws Throwable {
+
+                    // initialise custom properties
+                    initCustomMap();
+
+                    return null;
+                }
+            });
+        }
     }
     
     /**


### PR DESCRIPTION
This is basically a sanity check when RM is starting. 

The assumption RM makes is that the ContextRefreshedEvent happens once and it also happens when the DictionaryService has all the models loaded from the repository.

This doesn't appear to be correct in the case where Dynamic Extensions is in use, as this will refresh the context multiple times while a server is active.

We add a check to the `onApplicationEvent` listener method to:
- Ensure we don't initialise the custom map more than once
- Ensure that the Dictionary Service contains the `RM_CUSTOM_MODEL`
