### PR TITLE
Increase travis_wait to thirty minutes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ jdk:
   - oraclejdk8
 sudo: false
 install: true
-script: travis_wait mvn -B clean verify -Dcommunity -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+script: travis_wait 30 mvn -B clean verify -Dcommunity -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn


### PR DESCRIPTION
Our community build takes around about twenty minutes, and so was failing
occasionally with a time out.