### PR TITLE
fix bug encoding URI component for constraint value

### DIFF
--- a/rm-community/rm-community-share/source/web/rm/components/console/rm-list-of-values.js
+++ b/rm-community/rm-community-share/source/web/rm/components/console/rm-list-of-values.js
@@ -1345,7 +1345,7 @@
             if (selectedValueName)
             {
                // Note: extra manual encoding of %2F ("/") to enable correct HTTP request generation
-               this.widgets.accessDataSource.sendRequest("/" + parent.constraintName + "/values/" + encodeURIComponent(selectedValueName).replace("%2F", "%252F"),
+               this.widgets.accessDataSource.sendRequest("/" + parent.constraintName + "/values/" + encodeURIComponent(selectedValueName).replace(/%2F/g, "%252F"),
                {
                   success: successHandler,
                   failure: failureHandler,


### PR DESCRIPTION
The existing code only encodes the first slash in the value, not all slashes.

Thus, the UI does not currently properly handle values that have more than one slash.
