### PR TITLE
Remove the cm:versionable aspects from the .ftl files

### DIFF
--- a/rm-community/rm-community-repo/config/alfresco/module/org_alfresco_module_rm/bootstrap/RMDataDictionaryBootstrap.xml
+++ b/rm-community/rm-community-repo/config/alfresco/module/org_alfresco_module_rm/bootstrap/RMDataDictionaryBootstrap.xml
@@ -128,7 +128,6 @@
                            <cm:titled></cm:titled>
                            <cm:author></cm:author>
                            <app:inlineeditable></app:inlineeditable>
-                           <cm:versionable></cm:versionable>
                         </view:aspects>
                         <view:properties>
                            <app:editInline>
@@ -148,7 +147,6 @@
                            <cm:titled></cm:titled>
                            <cm:author></cm:author>
                            <app:inlineeditable></app:inlineeditable>
-                           <cm:versionable></cm:versionable>
                          </view:aspects>
                          <view:properties>
                            <sys:store-protocol>workspace</sys:store-protocol>
@@ -166,7 +164,6 @@
                            <cm:titled></cm:titled>
                            <cm:author></cm:author>
                            <app:inlineeditable></app:inlineeditable>
-                           <cm:versionable></cm:versionable>
                         </view:aspects>
                         <view:properties>
                            <sys:store-protocol>workspace</sys:store-protocol>


### PR DESCRIPTION
These are the only files in the Data Dictionary that have the versionable aspect.  It was causing a problem when updating the files in the entire repository to have Crypto docs encryption as the update to the node failed because of a null version label